### PR TITLE
pretty print・コマンドラインオプション・AI は投げ棒を見るべき

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,6 +50,7 @@ dependencies = [
  "cetkaik_compact_representation",
  "cetkaik_full_state_transition",
  "cetkaik_fundamental",
+ "cetkaik_render_to_console",
  "cetkaik_traits",
  "cetkaik_yhuap_move_candidates",
  "clap",
@@ -60,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "cetkaik_compact_representation"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a56d1181a54009f4eb99fa1e17acc947bea817d6340104c8c85bf9cec1c99a"
+checksum = "38584c85cd8918fe4618d28a97c04b7ca0acb159749d87792414f8cdce8d3ee3"
 dependencies = [
  "cetkaik_fundamental",
  "cetkaik_traits",
@@ -70,9 +82,9 @@ dependencies = [
 
 [[package]]
 name = "cetkaik_full_state_transition"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9092a91d6e63bc174e597143e259e14d68ee380f07b2fb97d7d54b4b37da968"
+checksum = "6d41432ce06ae2912fa90b2e33611fecf890e9885078d1af5cc2cd1758ca37d3"
 dependencies = [
  "cetkaik_calculate_hand",
  "cetkaik_fundamental",
@@ -96,10 +108,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "cetkaik_traits"
-version = "1.0.0"
+name = "cetkaik_naive_representation"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3695d04b0c0cee144c970ec55e2f55ca75a1607fc43bae9827ceb8c619c6479e"
+checksum = "bb948b2aaf5fd3bda99331d02ea1cd664a9abe6c1744f05a40da056e3a85ff5d"
+dependencies = [
+ "cetkaik_fundamental",
+ "cetkaik_traits",
+ "serde",
+]
+
+[[package]]
+name = "cetkaik_render_to_console"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f219c34b7356b52463a8eac471620c106dcb9c246aa510db691d7f61a91de6a5"
+dependencies = [
+ "cetkaik_compact_representation",
+ "cetkaik_fundamental",
+ "cetkaik_naive_representation",
+ "cetkaik_traits",
+ "colored",
+]
+
+[[package]]
+name = "cetkaik_traits"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6ec27a4843b1cfc3c36e012db9e9ef11730c30d1df0a0b19551fa82c0b2bf9"
 dependencies = [
  "cetkaik_fundamental",
 ]
@@ -156,6 +192,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
 ]
 
 [[package]]
@@ -216,6 +263,15 @@ checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
@@ -239,7 +295,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "io-lifetimes",
  "rustix",
  "windows-sys",
@@ -250,6 +306,12 @@ name = "itoa"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "cc"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+
+[[package]]
 name = "cetk_ai_k"
 version = "0.1.0"
 dependencies = [
@@ -29,6 +41,7 @@ dependencies = [
  "cetkaik_fundamental",
  "cetkaik_traits",
  "cetkaik_yhuap_move_candidates",
+ "clap",
  "rand",
 ]
 
@@ -109,12 +122,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "4.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
+dependencies = [
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "is-terminal",
+ "once_cell",
+ "strsim",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
 name = "enum_primitive"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4551092f4d519593039259a9ed8daedf0da12e5109c5280338073eaeb81180"
 dependencies = [
  "num-traits 0.1.43",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -138,6 +209,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+dependencies = [
+ "hermit-abi",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +256,12 @@ name = "libc"
 version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "maplit"
@@ -253,10 +367,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -318,6 +462,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.36.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,6 +513,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,6 +527,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -382,3 +555,91 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,10 @@ edition = "2021"
 [dependencies]
 cetkaik_calculate_hand = "1.0.0"
 cetkaik_fundamental = "1.0.0"
-cetkaik_full_state_transition = "1.0.0"
-cetkaik_traits = "1.0.0"
+cetkaik_full_state_transition = "1.0.1"
+cetkaik_traits = "1.0.1"
 cetkaik_yhuap_move_candidates = "1.0.0"
-cetkaik_compact_representation = "1.0.0"
+cetkaik_compact_representation = "1.0.2"
+cetkaik_render_to_console = "0.1.1"
 rand = { version = "0.8", features = ["small_rng"] }
 clap = { version = "4.0.32", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ cetkaik_traits = "1.0.0"
 cetkaik_yhuap_move_candidates = "1.0.0"
 cetkaik_compact_representation = "1.0.0"
 rand = { version = "0.8", features = ["small_rng"] }
+clap = { version = "4.0.32", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ cetkAIk
 現状、`CetkaikEngine` トレイトを実装している AI 同士を戦わせることができる。
 
 デバッグメッセージを最小限にして 10 試合走らせるためのコマンド：
+
 ```
-cargo run -- --hide-move --hide-board -c 10
+cargo run --release -- --hide-move --hide-board --hide-ciurl -c 10
+```
+
+または
+
+```
+cargo run --release -- --quiet -c 10
 ```

--- a/README.md
+++ b/README.md
@@ -2,3 +2,11 @@ cetkAIk
 ====
 
 机戦のAI
+
+# 使い方
+現状、`CetkaikEngine` トレイトを実装している AI 同士を戦わせることができる。
+
+デバッグメッセージを最小限にして 10 試合走らせるためのコマンド：
+```
+cargo run -- --hide-move --hide-board -c 10
+```

--- a/src/cetkaik_engine.rs
+++ b/src/cetkaik_engine.rs
@@ -21,6 +21,7 @@ pub trait CetkaikEngine<T: CetkaikRepresentation> {
         &mut self,
         m: &InfAfterStep_<T::AbsoluteCoord>,
         s: &ExcitedState_<T>,
+        ciurl: Option<usize>
     ) -> Option<AfterHalfAcceptance_<T::AbsoluteCoord>>;
     fn search_hand_resolved(&mut self, s: &HandExists_<T>) -> Option<TymokOrTaxot_<T>>;
 }

--- a/src/greedy.rs
+++ b/src/greedy.rs
@@ -82,8 +82,10 @@ impl<T: CetkaikRepresentation + Clone> CetkaikEngine<T> for GreedyPlayer {
                     {
                         continue;
                     }
-                    let ext_state = apply_inf_after_step(s, *m, self.config).unwrap().choose().0;
-                    if let Some(aha_move) = self.search_excited(m, &ext_state) {
+                    let (ext_state, inf_after_step_ciurl) =
+                        apply_inf_after_step(s, *m, self.config).unwrap().choose();
+                    if let Some(aha_move) = self.search_excited(m, &ext_state, inf_after_step_ciurl)
+                    {
                         if aha_move.dest.is_none() {
                             continue;
                         }
@@ -109,6 +111,7 @@ impl<T: CetkaikRepresentation + Clone> CetkaikEngine<T> for GreedyPlayer {
         &mut self,
         m: &InfAfterStep_<T::AbsoluteCoord>,
         s: &ExcitedState_<T>,
+        ciurl: Option<usize>,
     ) -> Option<AfterHalfAcceptance_<T::AbsoluteCoord>> {
         let candidates = s.get_candidates(self.config);
         let mut best_move = None;

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,8 +73,9 @@ fn do_match<T: CetkaikRepresentation + Clone>(
                 if !hide_ciurl {
                     println!("InfAfterStep ciurl: {:?}", inf_after_step_ciurl)
                 }
-                let aha_move: AfterHalfAcceptance_<T::AbsoluteCoord> =
-                    searcher.search_excited(&m, &ext_state, inf_after_step_ciurl).unwrap();
+                let aha_move: AfterHalfAcceptance_<T::AbsoluteCoord> = searcher
+                    .search_excited(&m, &ext_state, inf_after_step_ciurl)
+                    .unwrap();
                 if !hide_move {
                     println!("Move (excited) (Debug): {:?}", aha_move);
                     println!(
@@ -140,6 +141,10 @@ struct Args {
     #[arg(long, default_value_t = false)]
     hide_ciurl: bool,
 
+    /// Only print the winner
+    #[arg(long, default_value_t = false)]
+    quiet: bool,
+
     /// How many matches to run
     #[arg(short, long, default_value_t = 1)]
     count: u8,
@@ -156,9 +161,9 @@ fn main() {
             config,
             &mut GreedyPlayer::new(config),
             &mut GreedyPlayer::new(config),
-            args.hide_move,
-            args.hide_board,
-            args.hide_ciurl,
+            args.quiet || args.hide_move,
+            args.quiet || args.hide_board,
+            args.quiet || args.hide_ciurl,
         );
     }
 }

--- a/src/random_player.rs
+++ b/src/random_player.rs
@@ -32,6 +32,7 @@ impl<T: CetkaikRepresentation + Clone> CetkaikEngine<T> for RandomPlayer {
         &mut self,
         _m: &InfAfterStep_<T::AbsoluteCoord>,
         s: &ExcitedState_<T>,
+        inf_after_step_ciurl: Option<usize>
     ) -> Option<AfterHalfAcceptance_<T::AbsoluteCoord>> {
         let candidates = s.get_candidates(self.config);
         candidates.choose(&mut self.rng).copied()


### PR DESCRIPTION
## 追加した機能
- 盤面が見えたほうがデバッグがしやすいので、コンソールに流すように（`--hide-board` オプションで消せる）
- 対戦回数とかをコマンドラインオプションで選べるように
- 踏越え判定の投げ棒の値を見ないと AI は判断ができないはずなので、引数として渡すように

## こんな感じになったよ
<img width="647" alt="Capture d’écran 2022-12-24 à 9 57 18 AM" src="https://user-images.githubusercontent.com/21972349/209416241-99157811-cc5a-444c-8aff-695d65d9f90a.png">

